### PR TITLE
update npmignore to close #43

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -62,6 +62,7 @@ book.json
 docs/
 
 # do not publish 50mb of tmp files
-tmp2
+tmp2/
 
 # do not publish 8mb of coverage files
+coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -57,3 +57,11 @@ book.json
 # jscs et al config files:
 .js*
 .travis*
+
+# do not publish 50mb of documentation
+docs/
+
+# do not publish 50mb of tmp files
+tmp2
+
+# do not publish 8mb of coverage files


### PR DESCRIPTION
this extra 100+mb of stuff is causing now.sh (amazon lambda) deployments to fail as they run out of space